### PR TITLE
Add `--version` for printing the version

### DIFF
--- a/bin/numbat-send
+++ b/bin/numbat-send
@@ -4,6 +4,11 @@
 var yargs = require('yargs')
 var NumbatEmitter = require('numbat-emitter')
 
+if (process.argv.indexOf('--version') !== -1) {
+  console.log(require('../package.json').version)
+  process.exit(0)
+}
+
 var argv = yargs
   .alias('uri', 'u')
   .describe('uri', 'URI of the collector/analyzer to send to')
@@ -26,6 +31,8 @@ var argv = yargs
 
   .describe('tag', 'Any tag you want to send, in `--tag "foo=bar"` form')
   .array('tag')
+
+  .describe('version', 'Print version and exit')
 
   .argv
 


### PR DESCRIPTION
It's nice to be able to run `--version` on our tooling to determine the
versions present on the host instead of digging into global
`node_modules`.
