### PR TITLE
NSQ support + default to NSQ

### DIFF
--- a/bin/numbat-send
+++ b/bin/numbat-send
@@ -12,7 +12,7 @@ if (process.argv.indexOf('--version') !== -1) {
 var argv = yargs
   .alias('uri', 'u')
   .describe('uri', 'URI of the collector/analyzer to send to')
-  .default('uri', 'tcp://127.0.0.1:3333')
+  .default('uri', 'nsq://localhost:4150')
 
   .alias('app', 'a')
   .describe('app', 'Application name to use')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "numbat-send",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Send Numbat metrics from command line",
   "preferGlobal": true,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "numbat-send": "./bin/numbat-send"
   },
   "dependencies": {
-    "numbat-emitter": "^3.2.0",
-    "yargs": "~4.1.0"
+    "numbat-emitter": "^5.0.1",
+    "yargs": "^11.0.0"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
This makes our `numbat-send`-based ops metrics work again. It's also a breaking change, published as `0.2.0`.